### PR TITLE
Fix .gitignore path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-FS-Interiormanager
+FS-InteriorManager
 *.zip


### PR DESCRIPTION
## Summary
- ignore the build directory correctly by fixing the capitalisation in `.gitignore`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855f9c44f5883248d7ded32fdbfa2b3