### PR TITLE
Add debug logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 ### Documentation
 https://docs.fearlessdev.me/fivem-scripts/fs-interiormanager/
+
+### Usage
+Use the `/interiormanager` chat command to open the menu in game.  If you need
+verbose logs when interiors load, set `Config.debug = true` in `config.lua`.

--- a/src/client/client.lua
+++ b/src/client/client.lua
@@ -44,7 +44,9 @@ for _, interior in pairs(Config.Interiors) do
     local thisInterior = interior
     CreateThread(function()
         local interiorHandle = GetInteriorAtCoords(thisInterior.coords.x, thisInterior.coords.y, thisInterior.coords.z)
-        print("Interior handle for", thisInterior.id, "is", interiorHandle)
+        if Config.debug then
+            print("Interior handle for", thisInterior.id, "is", interiorHandle)
+        end
         while not IsInteriorReady(interiorHandle) do Wait(100) end
 
         activeInteriors[thisInterior.id] = interiorHandle
@@ -76,7 +78,9 @@ for _, folder in pairs(Config.InteriorFolders) do
         local thisInterior = interior
         CreateThread(function()
             local interiorHandle = GetInteriorAtCoords(thisInterior.coords.x, thisInterior.coords.y, thisInterior.coords.z)
-            print("Interior handle for", thisInterior.id, "is", interiorHandle)
+            if Config.debug then
+                print("Interior handle for", thisInterior.id, "is", interiorHandle)
+            end
             while not IsInteriorReady(interiorHandle) do Wait(100) end
 
             activeInteriors[thisInterior.id] = interiorHandle

--- a/src/config.lua
+++ b/src/config.lua
@@ -1,5 +1,9 @@
 Config = {}
 
+-- Print verbose debug information in the client console
+-- Set to true if you want to see interior loading logs
+Config.debug = false
+
 -- Command to open the interior manager
 Config.menuCommand = 'interiormanager'
 


### PR DESCRIPTION
## Summary
- add `Config.debug` flag to control logging
- wrap debug prints with the new flag
- document how to enable debug logs and how to open the menu

## Testing
- `npm run build` *(fails: Axios 403)*

------
https://chatgpt.com/codex/tasks/task_e_6855fb1fb7988324bd48362ac31939a6